### PR TITLE
PT-12801 track sql changes from original query

### DIFF
--- a/sql.sql
+++ b/sql.sql
@@ -1,8 +1,13 @@
 --POPULATE TABLES WITH IDS TO DELETE
 
-create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint, mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, covgtodelete boolean, monitorservice_id bigint);
+create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint, mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, covgtodelete boolean default false, monitorservice_id bigint);
 
-COPY uhs_non_vendor(vendornumber)
+create table uhs_non_vendor_voc(vocid bigint);
+create table uhs_delete_ms(msid bigint);
+create table uhs_non_vendor_imrs(imrid bigint);
+
+
+\COPY uhs_non_vendor(vendornumber)
 FROM '/Users/bgao/Downloads/VP_add_update_2023-08-14.csv'
 DELIMITER ','
 CSV HEADER;
@@ -18,8 +23,8 @@ covgid = cov.vendorgroup_id,
 monitorservice_id = cov.monitorservice_id
 from clientownedvendor cov
 where cov.vendornumber = anv.vendornumber
-and cov.createtime > '2023-08-14'
-and cov.createtime < '2023-08-16'
+and cov.createtime > '2023-08-15' --TODO change back to 08-14
+and cov.createtime < '2023-08-18' --TODO change back to 08-16
  and cov.client_id = 1509; --UHS
 
 update uhs_non_vendor unv set
@@ -27,18 +32,13 @@ update uhs_non_vendor unv set
  from clientownedvendorgroup covg
  where unv.covgid = covg.id
 and covg.trashed
-and createtime > '2023-08-14'
-and createtime < '2023-08-16'
-and cov.client_id = 1509;
---TODO spot check values to make sure covgtodelete is set like expected
-
-create table uhs_non_vendor_voc(vocid bigint);
+and createtime > '2023-08-16' --TODO change back to 08-14
+and createtime < '2023-08-18' --TODO change back to 08-16
+and covg.client_id = 1509;
 
 insert into uhs_non_vendor_voc(vocid)
 select distinct vendorownercollection_id from clientownedvendorgroup where id in (select covgid from uhs_non_vendor where covgtodelete) and vendorownercollection_id is not null;
---we expect this to be 0
-
-create table uhs_delete_ms(msid bigint);
+--we expect this to be 0, and is 0
 
 insert into uhs_delete_ms(msid)
 (select monitorservice_id from uhs_non_vendor where covgtodelete
@@ -48,57 +48,12 @@ select id from monitorservice2 where monitorsubject_id in
         (select id from vendorowner where vendorownercollection_id in 
             (select vocid from uhs_non_vendor_voc))));
 
-create table uhs_non_vendor_imrs(imrid bigint);
 
 insert into uhs_non_vendor_imrs(imrid)
 select id from intermediatemonitorrecord where monitoritem_id in 
     (select id from monitoritem where monitorservice_id in 
         (select msid from uhs_delete_ms));
 
-with recursive imr_down_chain(startingid, id, previousimr_id ) as 
-(
-    select id as startingid, id, previousimr_id from intermediatemonitorrecord where id in 
-        (select intermediatemonitorrecord_id from monitorrecord where monitorservice_id in 
-            (select monitorservice_id from uhs_delete_ms))
-    union
-    select down.startingid, imr.id, imr.previousimr_id from intermediatemonitorrecord imr inner join imr_down_chain down on down.previousimr_id = imr.id
-)
-insert into uhs_non_vendor_imrs(imrid)
-select distinct id from imr_down_chain where previousimr_id is null and id not in (select imrid from uhs_non_vendor_imrs);
---We hope that this is 0
-
-with recursive imr_up_chain as (
-    select imrid as startingid, imrid as id, null::bigint as previousimr_id from uhs_non_vendor_imrs
-    union
-    select up.startingid, imr2.id, imr2.previousimr_id from intermediatemonitorrecord imr2 inner join imr_up_chain up on up.id = imr2.previousimr_id
-)
-insert into uhs_non_vendor_imrs(imrid)
-select id from imr_up_chain where previousimr_id is not null and id not in (select imrid from uhs_non_vendor_imrs);
---We hope that this is 0
-
-
-
-create table uhs_non_vendor_sub(subid bigint);
-
-with recursive sub_up_chain as (
-    select id, parent_id from monitoredsubject2 where id in (select monitorsubject_id from monitorservice2 where id in (select msid from uhs_delete_ms))
-    union
-    select sub.id, sub.parent_id from monitoredsubject2 sub inner join sub_up_chain up on sub.id = up.parent_id
-)
-insert into uhs_non_vendor_sub(subid)
-select distinct id from sub_up_chain where parent_id is null;
-
--- I expect this to insert 0, but I'm doing it because it is theoretically possible
-with recursive sub_down_chain(id, parent_id) as (
-    select subid, null::bigint as parent_id from uhs_non_vendor_sub
-    union
-    select sub.id, sub.parent_id from monitoredsubject2 sub inner join sub_down_chain down on sub.parent_id = down.id
-)
-insert into uhs_non_vendor_sub(subid)
-select distinct id from sub_down_chain where parent_id is not null;
-
-insert into uhs_non_vendor_sub(subid)
-select distinct id from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc)) and id not in (select subid from uhs_non_vendor_sub);
 
 --IMRs and MRs
 delete from monitorrecordnote where monitorrecord_id in (select id from monitorrecord where monitorservice_id in (select msid from uhs_delete_ms));
@@ -121,6 +76,10 @@ delete from monitorservicestatuslog2 where service_id in (select msid from uhs_d
 
 delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from  monitoritem where monitorservice_id in (select msid from uhs_delete_ms));
 
+delete from monitoritemactiveperiod where monitoritem_id in (select id from monitoritem where monitorservice_id in (select msid from uhs_delete_ms));
+
+delete from monitorserviceactiveperiod where monitorservice_id in (select msid from uhs_delete_ms);
+
 delete from monitoritem where monitorservice_id in (select msid from uhs_delete_ms);
 
 delete from monitorservicerequest2_monitoritem where monitorservicerequest2_id in (select id from  monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms));
@@ -135,28 +94,29 @@ delete from monitorservicerequestlog where servicerequest_id in (select id from 
 
 delete from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms);
 
+delete from monitoredcovactiveperiod where monitorservice_id in (select msid from uhs_delete_ms);
+
 delete from monitorservice2 where id in (select msid from uhs_delete_ms);
 
 --MONITOR SUBJECT
-delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub)));
+delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from monitoritem where monitorservice_id in (select msid from uhs_delete_ms));
 
-delete from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub));
+delete from monitorobject where monitorsubject_id in (select id from monitoredsubject2 where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete));
 
-delete from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub);
+delete from monitorobject where monitorsubject_id in (select id from monitoredsubject2 where vendor_id in (select covid from uhs_non_vendor));
 
-delete from monitoredsubject2 where id in (select subid from uhs_non_vendor_sub);
-
---COV
 delete from monitoredsubject2 where vendor_id in (select covid from uhs_non_vendor);
 --if this does not return 0, we should be worried about the previous monitor subject queries
+
+delete from monitoredsubject2 where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+
+--COV
 
 delete from clientownedvendorevent where clientownedvendor_id in (select covid from uhs_non_vendor);
 
 delete from enrollmentmetadata where clientownedvendor_id in (select covid from uhs_non_vendor);
 
 delete from clientownedvendorlabel_assignments where clientownedvendor_id in (select covid from uhs_non_vendor);
-
-delete from clientownedvendor_clientvendorconnection where clientownedvendor_id in (select covid from uhs_non_vendor);
 
 delete from lawsonvendor where clientownedvendor_id in (select covid from uhs_non_vendor);
 
@@ -179,27 +139,41 @@ delete from address_line where id in (select designatedaddress_id from uhs_non_v
 delete from address_region where id in (select designatedaddress_id from uhs_non_vendor);
 
 delete from address where id in (select designatedaddress_id from uhs_non_vendor);
+--deleted 11293
 
 
 --COVG And VO
-delete from enrollmentmetadata where clientownedvendorgroup_id in (select covg from uhs_non_vendor where covgtodelete);
+delete from enrollmentmetadata where clientownedvendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
 
 delete from monitoredsubject2 where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+--got 0
 
 delete from clientownedvendorgroup_w9 where clientownedvendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+--got 0
 
 delete from compliancestatusevent_newnoncompliancereasons where compliancestatusevent_id in (select id from ComplianceStatusEvent where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete));
+--got 6686
 delete from compliancestatusevent_oldnoncompliancereasons where compliancestatusevent_id in (select id from ComplianceStatusEvent where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete));
+--got 4090
 delete from ComplianceStatusEvent where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+--got 10776
 
 delete from noncompliancereasons where clientownedvendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+--got 2596
 
+delete from signupcode where vendorgroup_id in (select covgid from uhs_non_vendor where covgtodelete);
+--newly added on 8/17 evening. These must have been created automatically
+--got 6637
 
 delete from clientownedvendorgroup where id in (select covgid from uhs_non_vendor where covgtodelete);
+--got 6637
+--last commit
 
 delete from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc));
+--0
 
 delete from vendorowner_monitorservice2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc));
+--0
 
 --These are not needed as the vendorowners are associated with actual vendors and contain no PII (see 2023 parts 1 and 2)
 --delete from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc);
@@ -210,7 +184,7 @@ delete from vendorowner_monitorservice2 where vendorowner_id in (select id from 
 
 --These are super slow due to a gajillion foreign keys. If there was any data in them we could delete them but there is no personal data in them
 --we'll try deleting these, but we can skip them if slow
-delete from role where id in (select primaryrepresentative_id from uhs_non_vendor);
-delete from role where id in (select secondaryrepresentative_id from uhs_non_vendor);
+--delete from role where id in (select primaryrepresentative_id from uhs_non_vendor);
+--delete from role where id in (select secondaryrepresentative_id from uhs_non_vendor);
 
 -- I am not going to put deleting of vendors in here because we really want to think hard about that before we do it in the future. If they have any other vendor connections, we shouldn't delete them. We don't want to delete them anyway, but in this case, we have to!

--- a/sql.sql
+++ b/sql.sql
@@ -20,8 +20,7 @@ from clientownedvendor cov
 where cov.vendornumber = anv.vendornumber
 and cov.createtime > '2023-08-14'
 and cov.createtime < '2023-08-16'
-and cov.trashed
- and cov.client_id = 1509 --UHS
+ and cov.client_id = 1509; --UHS
 
 update uhs_non_vendor unv set
  covgtodelete = TRUE
@@ -29,7 +28,8 @@ update uhs_non_vendor unv set
  where unv.covgid = covg.id
 and covg.trashed
 and createtime > '2023-08-14'
-and createtime < '2023-08-16';
+and createtime < '2023-08-16'
+and cov.client_id = 1509;
 --TODO spot check values to make sure covgtodelete is set like expected
 
 create table uhs_non_vendor_voc(vocid bigint);

--- a/sql.sql
+++ b/sql.sql
@@ -2,10 +2,13 @@
 
 create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint,  mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, monitorservice_id bigint);
 
-insert into uhs_non_vendor(vendornumber, covid)
-values;
+COPY uhs_non_vendor(vendornumber)
+FROM '/Users/bgao/Downloads/VP_add_update_2023-08-14.csv'
+DELIMITER ','
+CSV HEADER;
 
 update uhs_non_vendor anv set 
+covid = cov.id,
 name_id = cov.name_id,
 secondaryrepresentative_id = cov.secondaryrepresentative_id,
 primaryrepresentative_id = cov.primaryrepresentative_id,
@@ -14,7 +17,12 @@ designatedaddress_id = cov.designatedaddress_id,
 covgid = cov.vendorgroup_id,
 monitorservice_id = cov.monitorservice_id
 from clientownedvendor cov
-where cov.id = anv.covid;
+where cov.vendornumber = anv.vendornumber
+and cov.createtime > '2023-08-14'
+and cov.createtime < '2023-08-16'
+and cov.trashed
+ and cov.client_id = 1509 --UHS
+
 create table uhs_non_vendor_voc(vocid bigint);
 
 insert into uhs_non_vendor_voc(vocid)

--- a/sql.sql
+++ b/sql.sql
@@ -23,8 +23,8 @@ covgid = cov.vendorgroup_id,
 monitorservice_id = cov.monitorservice_id
 from clientownedvendor cov
 where cov.vendornumber = anv.vendornumber
-and cov.createtime > '2023-08-15' --TODO change back to 08-14
-and cov.createtime < '2023-08-18' --TODO change back to 08-16
+and cov.createtime > '2023-08-14'
+and cov.createtime < '2023-08-16'
  and cov.client_id = 1509; --UHS
 
 update uhs_non_vendor unv set
@@ -32,8 +32,8 @@ update uhs_non_vendor unv set
  from clientownedvendorgroup covg
  where unv.covgid = covg.id
 and covg.trashed
-and createtime > '2023-08-16' --TODO change back to 08-14
-and createtime < '2023-08-18' --TODO change back to 08-16
+and createtime > '2023-08-14'
+and createtime < '2023-08-16'
 and covg.client_id = 1509;
 
 insert into uhs_non_vendor_voc(vocid)

--- a/sql.sql
+++ b/sql.sql
@@ -1,6 +1,6 @@
 --POPULATE TABLES WITH IDS TO DELETE
 
-create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint,  mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, monitorservice_id bigint);
+create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint, mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, covgtrashed boolean, monitorservice_id bigint);
 
 COPY uhs_non_vendor(vendornumber)
 FROM '/Users/bgao/Downloads/VP_add_update_2023-08-14.csv'
@@ -23,11 +23,16 @@ and cov.createtime < '2023-08-16'
 and cov.trashed
  and cov.client_id = 1509 --UHS
 
+update uhs_non_vendor unv set
+ covgtrashed = covg.trashed
+ from clientownedvendorgroup covg
+ where unv.covgid = covg.id;
+--TODO spot check values
+
 create table uhs_non_vendor_voc(vocid bigint);
 
 insert into uhs_non_vendor_voc(vocid)
 select distinct vendorownercollection_id from clientownedvendorgroup where id in (select covgid from uhs_non_vendor) and vendorownercollection_id is not null;
-
 
 create table uhs_delete_ms(msid bigint);
 

--- a/sql.sql
+++ b/sql.sql
@@ -1,553 +1,11 @@
 --POPULATE TABLES WITH IDS TO DELETE
 
-create table ardent_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint,  mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, monitorservice_id bigint);
+create table uhs_non_vendor(vendornumber varchar, covid bigint, name_id bigint,  secondaryrepresentative_id bigint,  primaryrepresentative_id bigint,  mailingaddress_id bigint,  designatedaddress_id bigint, covgid bigint, monitorservice_id bigint);
 
-insert into ardent_non_vendor(vendornumber, covid)
-values
-( 55486, 5225348),
-( 58569, 5226016),
-( 62737, 5226031),
-( 36977, 5226936),
-( 42743, 5227025),
-( 44288, 5227034),
-( 62739, 5227699),
-( 62969, 5227725),
-( 63015, 5227745),
-( 63026, 5227749),
-( 63121, 5227791),
-( 63233, 5227844),
-( 63328, 5227882),
-( 63329, 5227883),
-( 63396, 5227910),
-( 63423, 5227918),
-( 63492, 5227945),
-( 63584, 5227971),
-( 64031, 5227999),
-( 64189, 5228022),
-( 64209, 5228031),
-( 64565, 5228093),
-( 64700, 5228134),
-( 67405, 5228412),
-( 67409, 5228413),
-( 67420, 5228414),
-( 67473, 5228415),
-( 67478, 5228417),
-( 67519, 5228419),
-( 67644, 5228427),
-( 67683, 5228440),
-( 67814, 5228448),
-( 67818, 5228449),
-( 67885, 5228450),
-( 67917, 5228451),
-( 67926, 5228452),
-( 67927, 5228453),
-( 67929, 5228454),
-( 67930, 5228455),
-( 67931, 5228456),
-( 67932, 5228457),
-( 67933, 5228458),
-( 67934, 5228459),
-( 67935, 5228460),
-( 67936, 5228461),
-( 67937, 5228462),
-( 67938, 5228463),
-( 67940, 5228464),
-( 67941, 5228465),
-( 67942, 5228466),
-( 67943, 5228467),
-( 67944, 5228468),
-( 67946, 5228469),
-( 67947, 5228470),
-( 67948, 5228471),
-( 67949, 5228472),
-( 67950, 5228473),
-( 67951, 5228474),
-( 67952, 5228475),
-( 67953, 5228476),
-( 67954, 5228477),
-( 67955, 5228478),
-( 67956, 5228479),
-( 67957, 5228480),
-( 67958, 5228481),
-( 67959, 5228482),
-( 67960, 5228483),
-( 67961, 5228484),
-( 67962, 5228485),
-( 67963, 5228486),
-( 67964, 5228487),
-( 67966, 5228488),
-( 67967, 5228489),
-( 67968, 5228490),
-( 67970, 5228491),
-( 68027, 5228499),
-( 67701, 5228523),
-( 67591, 5228524),
-( 67698, 5228528),
-( 67568, 5228530),
-( 67596, 5228532),
-( 67448, 5228533),
-( 67584, 5228534),
-( 67426, 5228539),
-( 67549, 5228540),
-( 67299, 5228542),
-( 67493, 5228545),
-( 67404, 5228546),
-( 67403, 5228547),
-( 67594, 5228548),
-( 67600, 5228549),
-( 67548, 5228552),
-( 67467, 5228554),
-( 67540, 5228556),
-( 67436, 5228562),
-( 67574, 5228563),
-( 67397, 5228568),
-( 67504, 5228570),
-( 67507, 5228573),
-( 67432, 5228576),
-( 67486, 5228577),
-( 67433, 5228580),
-( 67421, 5228583),
-( 67541, 5228584),
-( 67469, 5228586),
-( 67502, 5228587),
-( 67452, 5228588),
-( 67475, 5228589),
-( 67723, 5228590),
-( 67556, 5228591),
-( 67454, 5228600),
-( 67396, 5228601),
-( 67567, 5228602),
-( 67489, 5228603),
-( 67510, 5228604),
-( 67629, 5228609),
-( 67580, 5228610),
-( 67498, 5228612),
-( 67481, 5228613),
-( 67741, 5228614),
-( 67468, 5228617),
-( 67512, 5228618),
-( 67471, 5228619),
-( 67562, 5228620),
-( 67445, 5228621),
-( 67480, 5228623),
-( 67466, 5228625),
-( 67576, 5228627),
-( 67430, 5228628),
-( 67711, 5228635),
-( 67586, 5228645),
-( 67408, 5228646),
-( 67488, 5228651),
-( 67400, 5228654),
-( 67524, 5228655),
-( 67553, 5228656),
-( 67625, 5228659),
-( 67721, 5228663),
-( 67685, 5228664),
-( 67427, 5228666),
-( 67411, 5228667),
-( 67725, 5228668),
-( 67733, 5228669),
-( 67729, 5228670),
-( 67588, 5228673),
-( 67618, 5228674),
-( 67593, 5228675),
-( 67788, 5228676),
-( 67722, 5228677),
-( 67529, 5228678),
-( 67696, 5228679),
-( 67606, 5228680),
-( 67601, 5228683),
-( 67530, 5228684),
-( 67605, 5228686),
-( 67686, 5228690),
-( 67837, 5228692),
-( 67900, 5228695),
-( 67690, 5228697),
-( 67506, 5228698),
-( 67526, 5228699),
-( 67472, 5228702),
-( 67597, 5228712),
-( 67521, 5228713),
-( 67583, 5228714),
-( 67456, 5228715),
-( 67425, 5228717),
-( 67355, 5228719),
-( 67484, 5228720),
-( 67569, 5228721),
-( 67431, 5228725),
-( 67460, 5228729),
-( 67632, 5228733),
-( 67687, 5228734),
-( 67688, 5228737),
-( 67684, 5228738),
-( 67461, 5228743),
-( 67715, 5228744),
-( 67441, 5228745),
-( 67560, 5228746),
-( 67713, 5228747),
-( 67522, 5228749),
-( 67356, 5228750),
-( 67554, 5228754),
-( 67476, 5228756),
-( 67579, 5228757),
-( 67470, 5228758),
-( 67407, 5228759),
-( 67592, 5228760),
-( 67635, 5228762),
-( 67487, 5228765),
-( 67738, 5228772),
-( 67623, 5228773),
-( 67732, 5228781),
-( 67555, 5228783),
-( 67531, 5228787),
-( 67514, 5228793),
-( 67570, 5228794),
-( 67415, 5228799),
-( 67428, 5228800),
-( 67439, 5228801),
-( 67557, 5228802),
-( 67423, 5228803),
-( 67416, 5228804),
-( 67394, 5228805),
-( 67614, 5228808),
-( 67573, 5228809),
-( 67551, 5228810),
-( 67700, 5228813),
-( 67714, 5228817),
-( 67406, 5228818),
-( 67718, 5228819),
-( 67610, 5228822),
-( 67617, 5228824),
-( 67717, 5228825),
-( 67509, 5228827),
-( 67418, 5228828),
-( 67558, 5228830),
-( 67727, 5228831),
-( 67537, 5228832),
-( 67595, 5228834),
-( 67702, 5228840),
-( 67694, 5228845),
-( 67490, 5228846),
-( 67444, 5228847),
-( 67515, 5228849),
-( 67812, 5228851),
-( 67298, 5228852),
-( 67419, 5228853),
-( 67520, 5228854),
-( 67571, 5228855),
-( 67830, 5228856),
-( 67636, 5228858),
-( 67440, 5228860),
-( 67689, 5228862),
-( 67533, 5228863),
-( 67410, 5228864),
-( 67492, 5228865),
-( 67534, 5228866),
-( 67691, 5228867),
-( 67494, 5228868),
-( 67634, 5228869),
-( 67589, 5228881),
-( 67613, 5228885),
-( 67459, 5228886),
-( 67575, 5228889),
-( 67626, 5228890),
-( 67621, 5228891),
-( 67561, 5228892),
-( 67564, 5228893),
-( 67731, 5228894),
-( 67513, 5228896),
-( 67414, 5228898),
-( 67457, 5228899),
-( 67604, 5228902),
-( 67424, 5228903),
-( 67692, 5228904),
-( 67695, 5228906),
-( 67737, 5228907),
-( 67517, 5228909),
-( 67482, 5228911),
-( 67590, 5228912),
-( 67572, 5228918),
-( 67429, 5228921),
-( 67413, 5228922),
-( 67619, 5228923),
-( 67563, 5228925),
-( 67438, 5228927),
-( 67402, 5228929),
-( 67412, 5228930),
-( 67719, 5228934),
-( 67703, 5228935),
-( 67544, 5228936),
-( 67516, 5228939),
-( 67495, 5228940),
-( 67609, 5228941),
-( 67542, 5228943),
-( 67527, 5228946),
-( 67552, 5228947),
-( 67501, 5228951),
-( 67708, 5228952),
-( 67577, 5228956),
-( 67616, 5228957),
-( 67607, 5228958),
-( 67709, 5228959),
-( 67622, 5228960),
-( 67417, 5228963),
-( 67587, 5228964),
-( 67453, 5228965),
-( 67422, 5228966),
-( 67582, 5228967),
-( 67535, 5228968),
-( 67602, 5228969),
-( 67458, 5228970),
-( 67442, 5228972),
-( 67477, 5228974),
-( 67716, 5228975),
-( 67543, 5228976),
-( 67840, 5228977),
-( 67740, 5228979),
-( 67611, 5228983),
-( 67693, 5228985),
-( 67503, 5228986),
-( 67449, 5228987),
-( 67451, 5228990),
-( 67633, 5228992),
-( 67536, 5228993),
-( 67399, 5228995),
-( 67393, 5228996),
-( 67496, 5228997),
-( 67447, 5229000),
-( 67434, 5229001),
-( 67497, 5229005),
-( 67443, 5229008),
-( 67637, 5229010),
-( 67730, 5229011),
-( 67811, 5229016),
-( 67736, 5229018),
-( 67437, 5229020),
-( 67615, 5229021),
-( 67697, 5229022),
-( 67485, 5229024),
-( 67578, 5229026),
-( 67499, 5229027),
-( 67793, 5229028),
-( 67483, 5229029),
-( 67739, 5229032),
-( 67720, 5229037),
-( 67296, 5229041),
-( 67565, 5229043),
-( 67585, 5229046),
-( 67612, 5229047),
-( 67528, 5229049),
-( 67450, 5229053),
-( 67704, 5229056),
-( 67297, 5229057),
-( 67599, 5229059),
-( 67728, 5229060),
-( 67603, 5229066),
-( 67295, 5229069),
-( 67735, 5229072),
-( 67627, 5229073),
-( 63687, 5229109),
-( 63560, 5229284),
-( 67916, 5229482),
-( 67785, 5229485),
-( 67762, 5229496),
-( 67877, 5229500),
-( 67760, 5229523),
-( 67886, 5229524),
-( 67790, 5229526),
-( 67755, 5229529),
-( 67921, 5229531),
-( 67765, 5229532),
-( 67881, 5229533),
-( 67872, 5229534),
-( 67831, 5229541),
-( 67767, 5229546),
-( 67862, 5229547),
-( 67918, 5229548),
-( 67810, 5229564),
-( 67902, 5229565),
-( 67874, 5229566),
-( 67794, 5229569),
-( 67875, 5229570),
-( 67803, 5229572),
-( 67784, 5229574),
-( 67807, 5229576),
-( 67836, 5229580),
-( 67856, 5229582),
-( 67915, 5229585),
-( 67826, 5229589),
-( 67798, 5229590),
-( 67304, 5229593),
-( 67759, 5229594),
-( 67843, 5229596),
-( 67895, 5229600),
-( 67924, 5229602),
-( 67905, 5229605),
-( 67848, 5229617),
-( 67768, 5229636),
-( 67842, 5229659),
-( 67914, 5229660),
-( 67778, 5229670),
-( 67858, 5229673),
-( 67801, 5229675),
-( 67855, 5229688),
-( 67868, 5229689),
-( 67852, 5229690),
-( 67797, 5229691),
-( 67822, 5229697),
-( 67813, 5229698),
-( 67756, 5229701),
-( 67796, 5229704),
-( 67808, 5229706),
-( 67777, 5229707),
-( 67821, 5229709),
-( 67847, 5229710),
-( 67863, 5229711),
-( 67913, 5229712),
-( 67809, 5229713),
-( 67305, 5229714),
-( 67846, 5229715),
-( 67758, 5229716),
-( 67774, 5229718),
-( 67928, 5229729),
-( 67894, 5229735),
-( 67771, 5229785),
-( 67824, 5229801),
-( 67908, 5229802),
-( 67786, 5229803),
-( 67805, 5229804),
-( 67757, 5229807),
-( 67864, 5229808),
-( 67903, 5229809),
-( 67766, 5229815),
-( 67769, 5229823),
-( 67816, 5229825),
-( 67838, 5229826),
-( 67782, 5229827),
-( 67873, 5229828),
-( 67300, 5229829),
-( 67823, 5229830),
-( 67849, 5229833),
-( 67922, 5229834),
-( 67775, 5229839),
-( 67876, 5229841),
-( 67910, 5229842),
-( 67772, 5229846),
-( 67892, 5229857),
-( 67746, 5229858),
-( 67827, 5229859),
-( 67781, 5229860),
-( 67820, 5229864),
-( 67804, 5229865),
-( 67743, 5229866),
-( 67829, 5229870),
-( 67845, 5229882),
-( 67909, 5229998),
-( 67912, 5230015),
-( 67911, 5230017),
-( 67878, 5230022),
-( 67920, 5230027),
-( 67865, 5230035),
-( 67919, 5230038),
-( 67783, 5230040),
-( 67906, 5230043),
-( 67832, 5230057),
-( 67833, 5230058),
-( 67904, 5230065),
-( 67839, 5230115),
-( 67896, 5230116),
-( 67880, 5230118),
-( 67888, 5230130),
-( 67819, 5230148),
-( 67857, 5230159),
-( 67907, 5230180),
-( 67828, 5230182),
-( 67754, 5230183),
-( 67795, 5230184),
-( 67899, 5230199),
-( 67792, 5230205),
-( 67860, 5230206),
-( 67889, 5230207),
-( 67770, 5230212),
-( 67764, 5230213),
-( 67925, 5230217),
-( 67871, 5230218),
-( 67853, 5230219),
-( 67761, 5230226),
-( 67742, 5230230),
-( 67866, 5230237),
-( 67901, 5230257),
-( 67879, 5230258),
-( 67854, 5230269),
-( 67859, 5230270),
-( 67851, 5230275),
-( 67354, 5230278),
-( 67301, 5230279),
-( 67844, 5230282),
-( 67799, 5230283),
-( 67780, 5230285),
-( 67751, 5230289),
-( 67744, 5230292),
-( 67869, 5230294),
-( 67745, 5230300),
-( 67753, 5230301),
-( 67763, 5230315),
-( 67825, 5230427),
-( 67870, 5230428),
-( 67302, 5230715),
-( 67800, 5230735),
-( 67776, 5230777),
-( 67841, 5230798),
-( 67817, 5230799),
-( 67883, 5230804),
-( 67887, 5230835),
-( 67861, 5230836),
-( 67834, 5230837),
-( 67897, 5230877),
-( 67898, 5230878),
-( 67891, 5230893),
-( 67787, 5230927),
-( 67773, 5230929),
-( 67884, 5230932),
-( 67791, 5230940),
-( 67923, 5230941),
-( 67850, 5230942),
-( 67867, 5231354),
-( 67815, 5231358),
-( 67806, 5231359),
-( 67752, 5231360),
-( 67945, 5231361),
-( 67890, 5231365),
-( 67893, 5231373),
-( 67303, 5231394),
-( 67835, 5231405),
-( 67802, 5231408),
-( 67726, 5231412),
-( 67882, 5231419),
-( 60409, 5231722),
-( 62633, 5231768),
-( 64699, 5231833),
-( 65335, 5231836),
-( 67239, 5231838),
-( 63544, 5232423),
-( 45066, 5232577),
-( 59478, 5232662),
-( 62315, 5232697),
-( 62569, 5232734),
-( 62585, 5232735),
-( 62586, 5232736),
-( 62939, 5232741),
-( 63305, 5232750),
-( 63874, 5232756),
-( 64038, 5232758),
-( 67327, 5232775),
-( 54765, 5232796),
-( 62863, 5232843),
-( 62894, 5232854),
-( 62881, 5232861),
-( 62891, 5232872);
+insert into uhs_non_vendor(vendornumber, covid)
+values;
 
-update ardent_non_vendor anv set 
+update uhs_non_vendor anv set 
 name_id = cov.name_id,
 secondaryrepresentative_id = cov.secondaryrepresentative_id,
 primaryrepresentative_id = cov.primaryrepresentative_id,
@@ -557,162 +15,162 @@ covgid = cov.vendorgroup_id,
 monitorservice_id = cov.monitorservice_id
 from clientownedvendor cov
 where cov.id = anv.covid;
-create table ardent_non_vendor_voc(vocid bigint);
+create table uhs_non_vendor_voc(vocid bigint);
 
-insert into ardent_non_vendor_voc(vocid)
-select distinct vendorownercollection_id from clientownedvendorgroup where id in (select covgid from ardent_non_vendor) and vendorownercollection_id is not null;
+insert into uhs_non_vendor_voc(vocid)
+select distinct vendorownercollection_id from clientownedvendorgroup where id in (select covgid from uhs_non_vendor) and vendorownercollection_id is not null;
 
 
-create table ardent_delete_ms(msid bigint);
+create table uhs_delete_ms(msid bigint);
 
-insert into ardent_delete_ms(msid)
-(select monitorservice_id from ardent_non_vendor
+insert into uhs_delete_ms(msid)
+(select monitorservice_id from uhs_non_vendor
 union
-select id from monitorservice2 where monitorsubject_id in (select id from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from ardent_non_vendor_voc))));
+select id from monitorservice2 where monitorsubject_id in (select id from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc))));
 
-create table ardent_non_vendor_imrs(imrid bigint);
+create table uhs_non_vendor_imrs(imrid bigint);
 
 with recursive imr_down_chain(startingid, id, previousimr_id ) as (
-    select id as startingid, id, previousimr_id from intermediatemonitorrecord where id in (select intermediatemonitorrecord_id from monitorrecord where monitorservice_id in (select monitorservice_id from ardent_non_vendor))
+    select id as startingid, id, previousimr_id from intermediatemonitorrecord where id in (select intermediatemonitorrecord_id from monitorrecord where monitorservice_id in (select monitorservice_id from uhs_non_vendor))
     union
     select down.startingid, imr.id, imr.previousimr_id from intermediatemonitorrecord imr inner join imr_down_chain down on down.previousimr_id = imr.id
 )
-insert into ardent_non_vendor_imrs(imrid)
+insert into uhs_non_vendor_imrs(imrid)
 select distinct id from imr_down_chain where previousimr_id is null;
 
-insert into ardent_non_vendor_imrs(imrid)
-select id from intermediatemonitorrecord where monitoritem_id in (select id from monitoritem where monitorservice_id in (select msid from ardent_delete_ms)) and id not in (select imrid from ardent_non_vendor_imrs);
+insert into uhs_non_vendor_imrs(imrid)
+select id from intermediatemonitorrecord where monitoritem_id in (select id from monitoritem where monitorservice_id in (select msid from uhs_delete_ms)) and id not in (select imrid from uhs_non_vendor_imrs);
 
 with recursive imr_up_chain as (
-    select imrid as startingid, imrid as id, null::bigint as previousimr_id from ardent_non_vendor_imrs
+    select imrid as startingid, imrid as id, null::bigint as previousimr_id from uhs_non_vendor_imrs
     union
     select up.startingid, imr2.id, imr2.previousimr_id from intermediatemonitorrecord imr2 inner join imr_up_chain up on up.id = imr2.previousimr_id
 )
-insert into ardent_non_vendor_imrs(imrid)
+insert into uhs_non_vendor_imrs(imrid)
 select id from imr_up_chain where previousimr_id is not null;
 
-create table ardent_non_vendor_sub(subid bigint);
+create table uhs_non_vendor_sub(subid bigint);
 
 with recursive sub_up_chain as (
-    select id, parent_id from monitoredsubject2 where id in (select monitorsubject_id from monitorservice2 where id in (select msid from ardent_delete_ms))
+    select id, parent_id from monitoredsubject2 where id in (select monitorsubject_id from monitorservice2 where id in (select msid from uhs_delete_ms))
     union
     select sub.id, sub.parent_id from monitoredsubject2 sub inner join sub_up_chain up on sub.id = up.parent_id
 )
-insert into ardent_non_vendor_sub(subid)
+insert into uhs_non_vendor_sub(subid)
 select distinct id from sub_up_chain where parent_id is null;
 
 -- I expect this to insert 0, but I'm doing it because it is theoretically possible
 with recursive sub_down_chain(id, parent_id) as (
-    select subid, null::bigint as parent_id from ardent_non_vendor_sub
+    select subid, null::bigint as parent_id from uhs_non_vendor_sub
     union
     select sub.id, sub.parent_id from monitoredsubject2 sub inner join sub_down_chain down on sub.parent_id = down.id
 )
-insert into ardent_non_vendor_sub(subid)
+insert into uhs_non_vendor_sub(subid)
 select distinct id from sub_down_chain where parent_id is not null;
 
-insert into ardent_non_vendor_sub(subid)
-select distinct id from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from ardent_non_vendor_voc)) and id not in (select subid from ardent_non_vendor_sub);
+insert into uhs_non_vendor_sub(subid)
+select distinct id from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc)) and id not in (select subid from uhs_non_vendor_sub);
 
 --vendor connections
-create table ardent_non_vendor_vc(vcid bigint);
+create table uhs_non_vendor_vc(vcid bigint);
 
-insert into ardent_non_vendor_vc(vcid)
-select id from vendorconnection where vendorgroup_id in (select covgid from ardent_non_vendor);
+insert into uhs_non_vendor_vc(vcid)
+select id from vendorconnection where vendorgroup_id in (select covgid from uhs_non_vendor);
 --IMRs and MRs
-delete from monitorrecordnote where monitorrecord_id in (select id from monitorrecord where monitorservice_id in (select msid from ardent_delete_ms));
+delete from monitorrecordnote where monitorrecord_id in (select id from monitorrecord where monitorservice_id in (select msid from uhs_delete_ms));
 
-delete from monitorrecord where monitorservice_id in (select msid from ardent_delete_ms);
+delete from monitorrecord where monitorservice_id in (select msid from uhs_delete_ms);
 
-delete from intermediatemonitorrecordlabel_assignments where intermediatemonitorrecord_id in (select imrid from ardent_non_vendor_imrs );
+delete from intermediatemonitorrecordlabel_assignments where intermediatemonitorrecord_id in (select imrid from uhs_non_vendor_imrs );
 
-delete from intermediatemonitorrecord where id in (select imrid from ardent_non_vendor_imrs order by imrid desc);
+delete from intermediatemonitorrecord where id in (select imrid from uhs_non_vendor_imrs order by imrid desc);
 
 --monitor service
-update clientownedvendor set monitorservice_id = null where id in (select covid from ardent_non_vendor);
+update clientownedvendor set monitorservice_id = null where id in (select covid from uhs_non_vendor);
 
-delete from vendorowner_monitorservice2 where monitorservice_id in (select msid from ardent_delete_ms);
+delete from vendorowner_monitorservice2 where monitorservice_id in (select msid from uhs_delete_ms);
 
-delete from monitorservicestatuslog2_users where monitorservicestatuslog2_id in (select id from monitorservicestatuslog2 where service_id in (select msid from ardent_delete_ms));
+delete from monitorservicestatuslog2_users where monitorservicestatuslog2_id in (select id from monitorservicestatuslog2 where service_id in (select msid from uhs_delete_ms));
 
-delete from monitorservicestatuslog2 where service_id in (select msid from ardent_delete_ms);
+delete from monitorservicestatuslog2 where service_id in (select msid from uhs_delete_ms);
 
-delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from  monitoritem where monitorservice_id in (select msid from ardent_delete_ms));
+delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from  monitoritem where monitorservice_id in (select msid from uhs_delete_ms));
 
-delete from monitoritem where monitorservice_id in (select msid from ardent_delete_ms);
+delete from monitoritem where monitorservice_id in (select msid from uhs_delete_ms);
 
-delete from monitorservicerequest2_monitoritem where monitorservicerequest2_id in (select id from  monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms));
+delete from monitorservicerequest2_monitoritem where monitorservicerequest2_id in (select id from  monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms));
 
-delete from fileentity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms)));
+delete from fileentity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms)));
 
-delete from filesystementity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms)));
+delete from filesystementity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms)));
 
-delete from stream where streamid in (select streamid::bigint from fileentity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms))));
+delete from stream where streamid in (select streamid::bigint from fileentity where id in (select response_id from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms))));
 
-delete from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms));
+delete from monitorservicerequestlog where servicerequest_id in (select id from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms));
 
-delete from monitorservicerequest2 where monitorservice_id in (select msid from ardent_delete_ms);
+delete from monitorservicerequest2 where monitorservice_id in (select msid from uhs_delete_ms);
 
-delete from monitorservice2 where id in (select msid from ardent_delete_ms);
+delete from monitorservice2 where id in (select msid from uhs_delete_ms);
 
 --MONITOR SUBJECT
-delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from ardent_non_vendor_sub)));
+delete from monitorservicerequest2_monitoritem where monitoritems_id in (select id from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub)));
 
-delete from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from ardent_non_vendor_sub));
+delete from monitoritem where monitorobject_id in (select id from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub));
 
-delete from monitorobject where monitorsubject_id in (select subid from ardent_non_vendor_sub);
+delete from monitorobject where monitorsubject_id in (select subid from uhs_non_vendor_sub);
 
-delete from monitoredsubject2 where id in (select subid from ardent_non_vendor_sub);
+delete from monitoredsubject2 where id in (select subid from uhs_non_vendor_sub);
 --COV
-delete from monitoredsubject2 where vendor_id in (select covid from ardent_non_vendor);
+delete from monitoredsubject2 where vendor_id in (select covid from uhs_non_vendor);
 
-delete from clientownedvendorevent where clientownedvendor_id in (select covid from ardent_non_vendor);
+delete from clientownedvendorevent where clientownedvendor_id in (select covid from uhs_non_vendor);
 
-delete from enrollmentmetadata where clientownedvendor_id in (select covid from ardent_non_vendor);
+delete from enrollmentmetadata where clientownedvendor_id in (select covid from uhs_non_vendor);
 
-delete from clientownedvendorlabel_assignments where clientownedvendor_id in (select covid from ardent_non_vendor);
+delete from clientownedvendorlabel_assignments where clientownedvendor_id in (select covid from uhs_non_vendor);
 
-delete from clientownedvendor_clientvendorconnection where clientownedvendor_id in (select covid from ardent_non_vendor);
+delete from clientownedvendor_clientvendorconnection where clientownedvendor_id in (select covid from uhs_non_vendor);
 
-delete from lawsonvendor where clientownedvendor_id in (select covid from ardent_non_vendor);
+delete from lawsonvendor where clientownedvendor_id in (select covid from uhs_non_vendor);
 
-delete from clientownedvendor cov where id in (select covid from ardent_non_vendor);
+delete from clientownedvendor cov where id in (select covid from uhs_non_vendor);
 
-delete from address_line where id in (select mailingaddress_id from ardent_non_vendor);
+delete from address_line where id in (select mailingaddress_id from uhs_non_vendor);
 
-delete from address_region where id in (select mailingaddress_id from ardent_non_vendor);
+delete from address_region where id in (select mailingaddress_id from uhs_non_vendor);
 
-delete from address where id in (select mailingaddress_id from ardent_non_vendor);
+delete from address where id in (select mailingaddress_id from uhs_non_vendor);
 
-delete from address_line where id in (select designatedaddress_id from ardent_non_vendor);
+delete from address_line where id in (select designatedaddress_id from uhs_non_vendor);
 
-delete from address_region where id in (select designatedaddress_id from ardent_non_vendor);
+delete from address_region where id in (select designatedaddress_id from uhs_non_vendor);
 
-delete from address where id in (select designatedaddress_id from ardent_non_vendor);
+delete from address where id in (select designatedaddress_id from uhs_non_vendor);
 
 --COVG And VO
-update vendorconnection set vendorgroup_id = null where id in (select vcid from ardent_non_vendor_vc);
+update vendorconnection set vendorgroup_id = null where id in (select vcid from uhs_non_vendor_vc);
 
-delete from monitoredsubject2 where vendorgroup_id in (select covgid from ardent_non_vendor);
+delete from monitoredsubject2 where vendorgroup_id in (select covgid from uhs_non_vendor);
 
-delete from vendorgroupenrollment where vendorgroup_id in (select covgid from ardent_non_vendor);
+delete from vendorgroupenrollment where vendorgroup_id in (select covgid from uhs_non_vendor);
 
-delete from clientownedvendorgroup_w9 where clientownedvendorgroup_id in (select covgid from ardent_non_vendor);
+delete from clientownedvendorgroup_w9 where clientownedvendorgroup_id in (select covgid from uhs_non_vendor);
 
-delete from clientownedvendorgroup where id in (select covgid from ardent_non_vendor);
+delete from clientownedvendorgroup where id in (select covgid from uhs_non_vendor);
 
-delete from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from ardent_non_vendor_voc));
+delete from monitoredsubject2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc));
 
-delete from vendorowner_monitorservice2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from ardent_non_vendor_voc));
+delete from vendorowner_monitorservice2 where vendorowner_id in (select id from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc));
 
 --These are not needed as the vendorowners are associated with actual vendors and contain no PII (see 2023 parts 1 and 2)
---delete from vendorowner where vendorownercollection_id in (select vocid from ardent_non_vendor_voc);
+--delete from vendorowner where vendorownercollection_id in (select vocid from uhs_non_vendor_voc);
 
---update vendor set vendorownercollection_id = null where vendorownercollection_id in (select vocid from ardent_non_vendor_voc);
+--update vendor set vendorownercollection_id = null where vendorownercollection_id in (select vocid from uhs_non_vendor_voc);
 
---delete from vendorownercollection where id in (select vocid from ardent_non_vendor_voc);
+--delete from vendorownercollection where id in (select vocid from uhs_non_vendor_voc);
 --These are super slow due to a gajillion foreign keys. If there was any data in them we could delete them but there is no personal data in them
 
---delete from role where id in (select primaryrepresentative_id from ardent_non_vendor);
+--delete from role where id in (select primaryrepresentative_id from uhs_non_vendor);
 
---delete from role where id in (select secondaryrepresentative_id from ardent_non_vendor);
+--delete from role where id in (select secondaryrepresentative_id from uhs_non_vendor);
 -- I am not going to put deleting of vendors in here because we really want to think hard about that before we do it in the future. If they have any other vendor connections, we shouldn't delete them. We don't want to delete them anyway, but in this case, we have to!


### PR DESCRIPTION
We made some changes from the previous version. Most notably, we chose to be more conservative about deleting COVG/monitorobjects/monitorsubects, because in this instance COVs were grouped into previously-existing COVGs, and we don't want to delete data for the pre-existing ones